### PR TITLE
Revert "Merge conflicts"

### DIFF
--- a/stacks/library/templates/base.html
+++ b/stacks/library/templates/base.html
@@ -1,16 +1,10 @@
 {% load staticfiles %}
 
-<!DOCTYPE html>
-<html lang="en">
+<html>
     <head>
-<<<<<<< HEAD
         <title>Stacks</title>
         <link href="{% static 'css/bootstrap.min.css' %}" type="text/css" rel="stylesheet"/>
         <link href="{% static 'css/bootstrap-theme.min.css' %}" type="text/css" rel="stylesheet"/>
-=======
-        <title>PyMNtos Library</title>
-        <link href="{% static "css/bootstrap.min.css" %}" rel="stylesheet">
->>>>>>> 1867750de45ae8d9f0f217defff3b0a6e8f3c1ab
     </head>
     <body>
 

--- a/stacks/library/templates/books.html
+++ b/stacks/library/templates/books.html
@@ -4,7 +4,6 @@
 
 <h1>Books</h1>
 
-<<<<<<< HEAD
 <table class="table table-striped">
     <thead>
         <tr>
@@ -25,21 +24,6 @@
             </td>
         </tr>
     {% endfor %}
-=======
-<table>
-  <tr>
-    <td>Book</td>
-    <td>Author(s)</td>
-    <td></td>
-  </tr>
-  {% for book in books %}
-  <tr>
-    <td>{{ book.title }}</td>
-    <td>{{ book.authors }}</td>
-    <td></td>
-  </tr>
-  {% endfor %}
->>>>>>> 1867750de45ae8d9f0f217defff3b0a6e8f3c1ab
 </table>
 
 {% endblock %}


### PR DESCRIPTION
This reverts commit 43f68bb871b210a87962690dc374590e20156d67, reversing
changes made to 148128009fa5e3861fec36ca9515a8cca86353c9.

This will remove the conflict markers that were committed upstream. Fixing issue #19.

Please take a look and make sure I didn't remove any functionality. I missed the last meeting and might be a bit out of the loop.
